### PR TITLE
Changed reply to include the used model

### DIFF
--- a/src/commands/queryGpt.ts
+++ b/src/commands/queryGpt.ts
@@ -38,6 +38,6 @@ export default {
     });
 
     const gptResponse = chatCompletion.choices.map(response => `${response.message.content}`).join("\n");
-    interaction.editReply(`prompt: ${prompt.value} \n ${gptResponse}`);
+    interaction.editReply(`Prompt: ${prompt.value} \nAnswer:\n ${gptResponse} \nModel used: ${model.value}`);
   },
 };


### PR DESCRIPTION
Added a "Model used" field at the end of the response in order to clarify to the user (who might be reading in posterity and not remember which model he originally used) and everyone helping him what model was used.
